### PR TITLE
Add support for garage gate

### DIFF
--- a/motionblinds/motion_blinds.py
+++ b/motionblinds/motion_blinds.py
@@ -31,7 +31,7 @@ DEVICE_TYPE_DR = "10000002"  # Double Roller
 
 DEVICE_TYPE_WIFI_CURTAIN = "22000000"  # Curtain direct WiFi
 DEVICE_TYPE_WIFI_BLIND = "22000002"  # Standard Blind direct WiFi
-DEVICE_TYPE_WIFI_GATE = "22000005"  # Standard Garage gate (for example Krispol)
+DEVICE_TYPE_WIFI_GATE = "22000005"  # Garage gate direct WiFi (for example Krispol)
 DEVICE_TYPES_WIFI = [
     DEVICE_TYPE_WIFI_BLIND,
     DEVICE_TYPE_WIFI_CURTAIN,

--- a/motionblinds/motion_blinds.py
+++ b/motionblinds/motion_blinds.py
@@ -31,9 +31,11 @@ DEVICE_TYPE_DR = "10000002"  # Double Roller
 
 DEVICE_TYPE_WIFI_CURTAIN = "22000000"  # Curtain direct WiFi
 DEVICE_TYPE_WIFI_BLIND = "22000002"  # Standard Blind direct WiFi
+DEVICE_TYPE_WIFI_GATE = "22000005"  # Standard Garage gate (for example Krispol)
 DEVICE_TYPES_WIFI = [
     DEVICE_TYPE_WIFI_BLIND,
     DEVICE_TYPE_WIFI_CURTAIN,
+    DEVICE_TYPE_WIFI_GATE,
 ]  # Direct WiFi devices
 
 DEVICE_TYPES_CONTROLLER = DEVICE_TYPES_GATEWAY + DEVICE_TYPES_WIFI
@@ -632,7 +634,7 @@ class MotionGateway(MotionCommunication):
                     self._device_list[blind_mac] = MotionTopDownBottomUp(
                         gateway=self, mac=blind_mac, device_type=device_type
                     )
-                elif device_type in [DEVICE_TYPE_WIFI_BLIND, DEVICE_TYPE_WIFI_CURTAIN]:
+                elif device_type in [DEVICE_TYPE_WIFI_BLIND, DEVICE_TYPE_WIFI_CURTAIN, DEVICE_TYPE_WIFI_GATE]:
                     self._device_list[blind_mac] = MotionBlind(
                         gateway=self, mac=blind_mac, device_type=device_type
                     )
@@ -1071,6 +1073,7 @@ class MotionBlind:
             DEVICE_TYPE_DR,
             DEVICE_TYPE_WIFI_BLIND,
             DEVICE_TYPE_WIFI_CURTAIN,
+            DEVICE_TYPE_WIFI_GATE,
         ]:
             _LOGGER.warning(
                 "Device with mac '%s' has DeviceType '%s' that does not correspond to a known blind in Update function.",


### PR DESCRIPTION
I own Krispol Starcus garage gate drive with a "Gate Pro Connector" which turnes out to be compatible with this library after a few small changes.

Tested this on the 2 devices that I own and works without any issues. I'm able to open, close and set position of the gate.

Example status:
<MotionBlind mac: c8c9a305eafb, type: RollerBlind, status: Stopped, position: 100 %, angle: 0.0, limit: BothLimitsDetected, battery: None, None %, None V, charging: None, RSSI: -53 dBm, com: None>