### PR TITLE
Allow gateway and blind to have the same mac address

### DIFF
--- a/motionblinds/motion_blinds.py
+++ b/motionblinds/motion_blinds.py
@@ -666,7 +666,6 @@ class MotionGateway(MotionCommunication):
                 self._parse_update_response(message)
                 for callback in self._registered_callbacks.values():
                     callback()
-                return
             if mac not in self.device_list:
                 if self.device_list:
                     _LOGGER.warning(

--- a/motionblinds/motion_blinds.py
+++ b/motionblinds/motion_blinds.py
@@ -667,7 +667,7 @@ class MotionGateway(MotionCommunication):
                 for callback in self._registered_callbacks.values():
                     callback()
             if mac not in self.device_list:
-                if self.device_list:
+                if self.device_list and mac != self._gateway_mac:
                     _LOGGER.warning(
                         "Multicast push with mac '%s' not in device_list, message: '%s'",
                         mac,


### PR DESCRIPTION
In the Krispol gate drive the gateway and the blind is reported using the same mac address. This isn't an issue for synchronous API but when using the asyncio the blind callback was never triggered.

This commit makes us process both gateway and blind callbacks if they are reported with the same MAC address.