### PR TITLE
Make AC motor check more region agnostic

### DIFF
--- a/motionblinds/motion_blinds.py
+++ b/motionblinds/motion_blinds.py
@@ -1053,9 +1053,6 @@ class MotionBlind:
 
         if voltage >= 100.0:
             # AC motor
-            #There are a myriad of residential mains voltages, 
-            # but all of them seem to be over 100.
-            #https://en.wikipedia.org/wiki/Mains_electricity_by_country
             return None
 
         if voltage <= 0.0:

--- a/motionblinds/motion_blinds.py
+++ b/motionblinds/motion_blinds.py
@@ -1051,8 +1051,11 @@ class MotionBlind:
             # 4 cel battery pack (16.8V)
             return round((voltage - 14.6) * 100 / (16.8 - 14.6), 0)
 
-        if voltage == 220.0:
+        if voltage >= 100.0:
             # AC motor
+            #There are a myriad of residential mains voltages, 
+            # but all of them seem to be over 100.
+            #https://en.wikipedia.org/wiki/Mains_electricity_by_country
             return None
 
         if voltage <= 0.0:


### PR DESCRIPTION
Starting to get myself familiar with the codebase to try to resolve a bug I reported. I noticed this voltage check seems to be assuming an EU or UK mains voltage of 220. In the US it is 120 (or 110 depending on who you ask), and according to Wikipedia, some countries (Japan) go as low as 100!

Without some knowledge that regardless of what the true ac voltage is it gets reported as 220, I assumed this was something that might not be accurate in all cases and figured I'd submit a fix to open it up a bit.